### PR TITLE
Fix Bugs in Connection Initialization and Stopping Process

### DIFF
--- a/portal/handlers/string_handler.py
+++ b/portal/handlers/string_handler.py
@@ -10,7 +10,7 @@ from ..data_struct.mesh import Mesh
 
 class StringHandler:
     @staticmethod
-    def handle_string(payload, data_type, index, channel_name):
+    def handle_string(payload, data_type, uuid, channel_name):
         """Handle generic string data for different types."""
         if payload is None:
             return

--- a/portal/handlers/string_handler.py
+++ b/portal/handlers/string_handler.py
@@ -48,7 +48,7 @@ class StringHandler:
                 layer_path, layer_mat = channel_name, None
             mesh.create_or_replace(object_name=f"obj_{i}_{channel_name}", layer_path=layer_path)
 
-            if metadata.get("Material"):
+            if metadata and metadata["Material"]:
                 # if material is string
                 if isinstance(metadata["Material"], str):
                     mesh.apply_material(metadata["Material"])

--- a/portal/server/websockets_server.py
+++ b/portal/server/websockets_server.py
@@ -29,6 +29,7 @@ class WebSocketServerManager:
         self._app = None
         self._runner = None
         self._site = None
+        self.loop = None  # asyncio loop reference
 
     async def websocket_handler(self, request):
         if not DEPENDENCIES_AVAILABLE:
@@ -57,6 +58,8 @@ class WebSocketServerManager:
                     raise ValueError(f"Unsupported message type: {msg.type}")
         except Exception as e:
             raise RuntimeError(f"Unhandled exception in websocket_handler: {e}")
+        finally:
+            await ws.close()
         return ws
 
     async def run_server(self):
@@ -77,7 +80,10 @@ class WebSocketServerManager:
             await self._site.start()
 
             while not self.shutdown_event.is_set():
-                await asyncio.sleep(1)
+                try:
+                    await asyncio.sleep(1)
+                except asyncio.CancelledError:
+                    break  # Properly exit the loop when the task is cancelled
 
             await self._runner.cleanup()
         except Exception as e:
@@ -88,21 +94,52 @@ class WebSocketServerManager:
             return
 
         self.shutdown_event.clear()
-        self._server_thread = threading.Thread(
-            target=asyncio.run, args=(self.run_server(),), daemon=True
-        )
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+        self._server_thread = threading.Thread(target=self._run_loop_in_thread, daemon=True)
         self._server_thread.start()
+
         print(
             f"WebSocket server started for connection uuid: {self.uuid}, name: {self.connection.name}"
         )
+
+    def _run_loop_in_thread(self):
+        self.loop.run_until_complete(self.run_server())
+        self.loop.run_forever()
+
+    async def shutdown_server(self):
+        if self._runner:
+            # Get the current task (the one running shutdown_server)
+            current_task = asyncio.current_task(loop=self.loop)
+
+            # Cancel all other tasks except the current one
+            tasks = [
+                task
+                for task in asyncio.all_tasks(self.loop)
+                if task is not current_task and not task.done()
+            ]
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+            # Clean up the site and runner
+            await self._runner.cleanup()
+
+        # Stop the loop
+        self.loop.stop()
 
     def stop_server(self):
         if not DEPENDENCIES_AVAILABLE:
             return
 
         self.shutdown_event.set()
+        if self.loop:
+            asyncio.run_coroutine_threadsafe(self.shutdown_server(), self.loop)
+
         if self._server_thread:
             self._server_thread.join(1)
+
         print(
             f"WebSocket server stopped for connection uuid: {self.uuid}, name: {self.connection.name}"
         )

--- a/portal/utils/managers.py
+++ b/portal/utils/managers.py
@@ -6,37 +6,37 @@ from ..server.websockets_server import WebSocketServerManager
 # Dictionary to store instances of server managers for each connection
 SERVER_MANAGERS = {}
 
-def get_server_manager(connection_type, index):
+def get_server_manager(connection_type, uuid):
     """
-    Retrieves or creates a new server manager instance for the given connection type and index.
+    Retrieves or creates a new server manager instance for the given connection type and uuid.
     If a different connection type was previously used, it removes the old one and creates a new instance.
     """
-    # Check if the server manager already exists for this index
-    if index in SERVER_MANAGERS:
-        existing_manager, existing_type = SERVER_MANAGERS[index]
+    # Check if the server manager already exists for this uuid
+    if uuid in SERVER_MANAGERS:
+        existing_manager, existing_type = SERVER_MANAGERS[uuid]
         
         # If the existing server manager is of a different type, remove it and create a new one
         if existing_type != connection_type:
             existing_manager.stop_server()  # Stop the current server if running
-            remove_server_manager(index)  # Remove the current manager from the dictionary
+            remove_server_manager(uuid)  # Remove the current manager from the dictionary
 
-    # If no server manager exists for this index or it was removed, create a new one
-    if index not in SERVER_MANAGERS:
+    # If no server manager exists for this uuid or it was removed, create a new one
+    if uuid not in SERVER_MANAGERS:
         # Create a new server manager based on the connection type
         if connection_type == "NAMED_PIPE":
-            manager = PipeServerManager(index)
+            manager = PipeServerManager(uuid)
         elif connection_type == "MMAP":
-            manager = MMFServerManager(index)
+            manager = MMFServerManager(uuid) # todo: update uuid
         elif connection_type == "WEBSOCKETS":
-            manager = WebSocketServerManager(index)
+            manager = WebSocketServerManager(uuid) # todo: update uuid
         elif connection_type == "UDP":
-            manager = UDPServerManager(index)
+            manager = UDPServerManager(uuid) # todo: update uuid
         else:
             raise ValueError(f"Unknown connection type: {connection_type}")
         
-        SERVER_MANAGERS[index] = (manager, connection_type)
+        SERVER_MANAGERS[uuid] = (manager, connection_type)
     
-    return SERVER_MANAGERS[index][0]  # Return the manager instance
+    return SERVER_MANAGERS[uuid][0]  # Return the manager instance
 
 def remove_server_manager(index):
     """


### PR DESCRIPTION
### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Description of Change
- **fix**
  - Resolved websocket blocking the main thread when stopping (b3e6cd9)
  - Implemented UUIDs as identifiers to prevent incorrect index shifts on component deletion (d9ee30e)
  - Handled cases where metadata is `None` (4857051)