### PR TITLE
Improve UI for Text Editor Button and Fix Window Opening Orientation

### DIFF
--- a/portal/ui/operators/text_editor.py
+++ b/portal/ui/operators/text_editor.py
@@ -66,20 +66,17 @@ class PORTAL_OT_OpenTextEditor(bpy.types.Operator):
                 area.spaces.active.text = text
                 return {"FINISHED"}
 
-        # Try to find a non-critical area (e.g., VIEW_3D or OUTLINER) to turn into a TEXT_EDITOR
+        # Open a new window with a TEXT_EDITOR if no suitable area exists
+        bpy.ops.screen.area_split(direction='VERTICAL', factor=0.5)
+        new_area = None
         for area in context.screen.areas:
-            if area.type not in {"PROPERTIES", "OUTLINER", "PREFERENCES", "INFO"}:
-                area.type = "TEXT_EDITOR"
-                area.spaces.active.text = text
-                return {"FINISHED"}
+            if area.type == 'VIEW_3D':
+                new_area = area
+                break
 
-        # If no suitable area, open a new window with a TEXT_EDITOR
-        new_window = bpy.ops.screen.area_split(direction="VERTICAL", factor=0.5)
-        if new_window == "FINISHED":
-            for area in context.screen.areas:
-                if area.type == "TEXT_EDITOR":
-                    area.spaces.active.text = text
-                    break
+        if new_area:
+            new_area.type = 'TEXT_EDITOR'
+            new_area.spaces.active.text = text
 
         return {"FINISHED"}
 

--- a/portal/ui/panels/server_control.py
+++ b/portal/ui/panels/server_control.py
@@ -108,8 +108,8 @@ class PORTAL_PT_ServerControl(bpy.types.Panel):
         ).uuid = connection.uuid
 
         if connection.custom_handler:
-            box.operator(
-                "portal.open_text_editor", text="Open in Text Editor"
+            row.operator(
+                "portal.open_text_editor", text="", icon="ZOOM_ALL"
             ).text_name = connection.custom_handler
 
 


### PR DESCRIPTION
### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [x] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Change Log
- **fix**
  - Ensure text editor opens in vertical split instead of default horizontal direction (9c0a9c5)
- **style**
  - Replace text with icon for open text editor button and align horizontally for compactness (6b1428d)

### Note
These changes were made to improve the user interface by replacing the lengthy and unattractive 'open text editor' button with a more compact icon. Additionally, the orientation issue of the text editor window opening in the default horizontal direction has been fixed to open vertically.

### Screenshot
| **Before** | **After** |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5b061a83-f428-4f25-ab97-c11b1d520547) | ![image](https://github.com/user-attachments/assets/430fe9a2-57a1-45e3-94f4-f6b5760b259a) |
