### PR TITLE
Optimize mesh data sending with time threshold and fix event handler registration issue

### DIFF
--- a/portal/data_struct/mesh.py
+++ b/portal/data_struct/mesh.py
@@ -18,45 +18,18 @@ class Mesh:
         self.mesh_data = None
         self.object_name = None
 
-    def to_dict(self, meta: dict | None = None, is_float=False, precision: float | None = None) -> dict:
+    def to_dict(self, meta: dict | None = None) -> dict:
         """
         Convert the mesh data to a dictionary for serialization.
 
         Args:
             meta (dict | None): Metadata dictionary.
-            is_float (bool): Whether to convert values to floats.
-            precision (float | None): Precision value to determine rounding.
 
         Returns:
             dict: Serialized mesh data.
         """
-        def apply_precision(value, precision):
-            """Helper function to round a value according to the specified precision."""
-            if precision:
-                return round(value / precision) * precision
-            return value
-
-        if is_float and precision is not None:
-            # Apply precision rounding to vertices and uvs
-            vertices = [
-                {"X": apply_precision(v[0], precision),
-                 "Y": apply_precision(v[1], precision),
-                 "Z": apply_precision(v[2], precision)}
-                for v in self.vertices
-            ]
-            uvs = [
-                {"X": apply_precision(uv[0], precision),
-                 "Y": apply_precision(uv[1], precision)}
-                for uv in self.uvs
-            ]
-        elif is_float:
-            # Default behavior without precision
-            vertices = [{"X": float(v[0]), "Y": float(v[1]), "Z": float(v[2])} for v in self.vertices]
-            uvs = [{"X": float(uv[0]), "Y": float(uv[1])} for uv in self.uvs]
-        else:
-            # Non-float serialization
-            vertices = [{"X": v[0], "Y": v[1], "Z": v[2]} for v in self.vertices]
-            uvs = [{"X": uv[0], "Y": uv[1]} for uv in self.uvs]
+        vertices = [{"X": v[0], "Y": v[1], "Z": v[2]} for v in self.vertices]
+        uvs = [{"X": uv[0], "Y": uv[1]} for uv in self.uvs]
 
         mesh_dict = {
             "Type": PGeoType.MESH.value,

--- a/portal/ui/operators/connections.py
+++ b/portal/ui/operators/connections.py
@@ -96,6 +96,11 @@ class PORTAL_OT_ToggleServer(bpy.types.Operator):
                 server_manager.stop_server()
                 connection.running = False
                 CONNECTION_MANAGER.remove(self.uuid)  # Remove the manager from SERVER_MANAGERS
+                # Cancel the modal operator if it is running and unregister the event handlers
+                if self.uuid in MODAL_OPERATORS:
+                    modal_operator = MODAL_OPERATORS[self.uuid]
+                    modal_operator.cancel(context)  # This will trigger _unregister_event_handlers
+                    modal_operator._unregister_event_handlers()  # Ensuring handlers are unregistered
         else:
             # Start the server if it's not running
             if server_manager and not server_manager.is_running():

--- a/portal/ui/operators/modal.py
+++ b/portal/ui/operators/modal.py
@@ -1,3 +1,4 @@
+import time
 import queue
 import traceback
 
@@ -22,6 +23,7 @@ class ModalOperator(bpy.types.Operator):
         self.frame_change_handler = None
         self.scene_update_handler = None
         self.custom_event_handler = None
+        self.last_update_time = 0  # Track the last update time for the delay
 
     def modal(self, context, event):
         connection = self._get_connection(context)
@@ -79,8 +81,9 @@ class ModalOperator(bpy.types.Operator):
     def _handle_send_event(self, context, connection, server_manager):
         try:
             message_to_send = construct_packet_dict(connection.dict_items)
-            if message_to_send:
-                server_manager.data_queue.put(message_to_send)
+            if not message_to_send or message_to_send == "{}" or message_to_send == "[]":
+                return
+            server_manager.data_queue.put(message_to_send)
         except Exception as e:
             self._report_error(
                 context,
@@ -140,6 +143,12 @@ class ModalOperator(bpy.types.Operator):
         return {"CANCELLED"}
 
     def _send_data_on_event(self, scene, connection):
+        current_time = time.time()
+        if current_time - self.last_update_time < connection.event_timer:
+            return  # Skip sending if within the delay threshold
+
+        self.last_update_time = current_time  # Update the last event time
+
         server_manager = self._get_server_manager(connection)
         if not server_manager:
             return
@@ -166,23 +175,18 @@ class ModalOperator(bpy.types.Operator):
 
     def _register_event_handlers(self, connection):
         if "RENDER_COMPLETE" in connection.event_types:
-            # https://docs.blender.org/api/current/bpy.app.handlers.html#bpy.app.handlers.render_complete
             self.render_complete_handler = lambda scene: self._send_data_on_event(scene, connection)
             bpy.app.handlers.render_complete.append(self.render_complete_handler)
 
         if "FRAME_CHANGE" in connection.event_types:
-            # https://docs.blender.org/api/current/bpy.app.handlers.html#bpy.app.handlers.frame_change_post
             self.frame_change_handler = lambda scene: self._send_data_on_event(scene, connection)
             bpy.app.handlers.frame_change_post.append(self.frame_change_handler)
 
         if "SCENE_UPDATE" in connection.event_types:
-            # on any scene event
-            # https://docs.blender.org/api/current/bpy.app.handlers.html#bpy.app.handlers.depsgraph_update_post
             self.scene_update_handler = lambda scene: self._send_data_on_event(scene, connection)
             bpy.app.handlers.depsgraph_update_post.append(self.scene_update_handler)
 
         if "CUSTOM" in connection.event_types:
-            # Custom event
             try:
                 handler = CustomHandler.load(
                     connection.custom_handler,

--- a/portal/ui/operators/modal.py
+++ b/portal/ui/operators/modal.py
@@ -78,7 +78,7 @@ class ModalOperator(bpy.types.Operator):
 
     def _handle_send_event(self, context, connection, server_manager):
         try:
-            message_to_send = construct_packet_dict(connection.dict_items, connection.precision)
+            message_to_send = construct_packet_dict(connection.dict_items)
             if message_to_send:
                 server_manager.data_queue.put(message_to_send)
         except Exception as e:

--- a/portal/ui/panels/server_control.py
+++ b/portal/ui/panels/server_control.py
@@ -89,7 +89,6 @@ class PORTAL_PT_ServerControl(bpy.types.Panel):
                         sub_box.prop(connection, "event_timer", text="Interval (sec)")
                     
                     if not connection.event_types == "CUSTOM":
-                        sub_box.prop(connection, "precision", text="Precision")
                         sub_box.separator()
                         sub_box.operator(
                             "portal.dict_item_editor", text="Data Editor", icon="MODIFIER_DATA"

--- a/portal/ui/panels/server_control.py
+++ b/portal/ui/panels/server_control.py
@@ -85,10 +85,8 @@ class PORTAL_PT_ServerControl(bpy.types.Panel):
                     sub_box.prop(connection, "event_types", text="Trigger Event")
                     if connection.event_types == "CUSTOM":
                         self._draw_custom_handler(sub_box, connection)
-                    elif connection.event_types == "TIMER":
-                        sub_box.prop(connection, "event_timer", text="Interval (sec)")
-                    
                     if not connection.event_types == "CUSTOM":
+                        sub_box.prop(connection, "event_timer", text="Interval (sec)")
                         sub_box.separator()
                         sub_box.operator(
                             "portal.dict_item_editor", text="Data Editor", icon="MODIFIER_DATA"

--- a/portal/ui/properties/connection_properties.py
+++ b/portal/ui/properties/connection_properties.py
@@ -61,11 +61,6 @@ class PortalConnection(bpy.types.PropertyGroup):
             ("CUSTOM", "Custom", "Trigger on custom event"),
         ],
     )
-    precision: bpy.props.FloatProperty(
-        name="Update Precision",
-        description="minimum numerical change to trigger an update",
-        default=0.01,
-    )
     dict_items: bpy.props.CollectionProperty(type=DictionaryItem)
     dict_items_index: bpy.props.IntProperty(default=0)
 

--- a/portal/ui/ui_utils/helper.py
+++ b/portal/ui/ui_utils/helper.py
@@ -13,7 +13,7 @@ def is_connection_duplicated(connections, name_to_check, uuid_to_ignore=None):
     return False
 
 
-def construct_packet_dict(data_items, update_precision) -> str:
+def construct_packet_dict(data_items) -> str:
     """Helper function to construct a dictionary from a collection of dictionary items"""
     payload = Payload()
     meta = {}
@@ -34,7 +34,7 @@ def construct_packet_dict(data_items, update_precision) -> str:
             scene_obj = item.value_scene_object
             if scene_obj.type == "MESH":
                 payload.add_items(
-                    Mesh.from_obj(scene_obj).to_dict(is_float=True, precision=update_precision)
+                    Mesh.from_obj(scene_obj).to_dict()
                 )
             elif scene_obj.type == "CAMERA":
                 raise NotImplementedError("Camera object type is not supported yet")


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [x] :hammer: chore
- [x] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Change Log
- **feat**
  - Make `event_timer` property accessible to all send methods except custom. (c9b7a8d)
- **fix**
  - Unregister event handlers after stopping the connection to prevent conflict when switching handlers. (a3aab3f)
- **perf**
  - Implement time threshold to optimize data sending, reducing data transmission and lag. (f077f72)
- **chore**
  - Remove unused `precision` parameter as it had no effect on performance. (54f0325)

### Note
This release optimizes the mesh data sending process by introducing a time threshold mechanism, reducing the frequency of data transmissions, which in turn lowers overhead and reduces lag. Additionally, it fixes an issue where event handlers were not being unregistered after stopping the connection, preventing conflicts when switching to new handlers.