### PR TITLE
fix: handle 0 light intensity without raising invalid value error

### DIFF
--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -166,7 +166,7 @@ class Light:
         type: str = data.get("LightType")
         energy: float = data.get("Intensity")
         pos: dict = data.get("Position")
-        if not all([type, energy, pos]):
+        if not all([type, pos]) or energy is None:
             raise ValueError(f"Missing required light data. Got: {data}")
         location = (pos["X"], pos["Y"], pos["Z"])
         light._set_light_data(name, color, energy, type, location)

--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,6 @@ You can create custom handlers to manipulate the data that is received. To do th
 ![alt text](/doc/images/custom-handler.png)
 
 ## Roadmap
-### v0.2.2
-- [ ] Fix area light position and rotation.
 ### v0.3.0
 - [ ] Add mouse up / down event for the sender.
 - [ ] Simplify the mesh vertex data into a list of tuples. `[[x, y, z], [x, y, z], ...]`


### PR DESCRIPTION
- Corrected condition to allow zero values in light intensity without triggering errors.

### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Description of Change
Corrected condition to allow zero values in light intensity without triggering errors. (8e43b3555a82bf49e75004a3bcaa19ea303de14c)