### PR TITLE
fix: send initial data on server start

### DIFF
--- a/portal/ui/operators/modal.py
+++ b/portal/ui/operators/modal.py
@@ -67,6 +67,10 @@ class ModalOperator(bpy.types.Operator):
         MODAL_OPERATORS[self.uuid] = self
         self._register_event_handlers(connection)
 
+        if connection.direction == "SEND":
+            # send initial data
+            self._handle_send_event(context, connection, self._get_server_manager(connection))
+
         return {"RUNNING_MODAL"}
 
     def cancel(self, context):


### PR DESCRIPTION
- Immediate data send after server start

### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Description of Change
- Immediate the initial data send after server start rather than waiting for event to trigger.