### PR TITLE
fix: normalize light color

### DIFF
--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -162,7 +162,7 @@ class Light:
     def from_dict(data: dict) -> "Light":
         light = Light()
         name: str = data.get("Name")
-        color: tuple = Color.from_hex(data.get("Color", "#FFFFFF")).to_tuple("rgb")
+        color: tuple = Color.from_hex(data.get("Color", "#FFFFFF")).to_tuple("rgb", normalize=True)
         type: str = data.get("LightType")
         energy: float = data.get("Intensity")
         pos: dict = data.get("Position")


### PR DESCRIPTION
### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Description of Change
- Blender is using normalized color value rather than `0-255`