### PR TITLE
Implement Light Conversion and Data Model Adaptation; Fix sRGB to Linear Conversion

### DIFF
--- a/portal/data_struct/camera.py
+++ b/portal/data_struct/camera.py
@@ -52,7 +52,7 @@ class Camera:
 
         self._set_camera_resolution()
         self._set_camera_fov_and_lens()
-    
+
     def set_cliping(self, near, far):
         cam = self.camera_object
         cam.data.clip_start = near
@@ -112,16 +112,16 @@ class Camera:
     def from_dict(camera_dict):
         """Create a Camera object from raw data."""
         position = (
-            camera_dict["Position"]["X"],
-            camera_dict["Position"]["Y"],
-            camera_dict["Position"]["Z"],
+            camera_dict["Position"][0],
+            camera_dict["Position"][1],
+            camera_dict["Position"][2],
         )
         look_direction = (
-            camera_dict["LookDirection"]["X"],
-            camera_dict["LookDirection"]["Y"],
-            camera_dict["LookDirection"]["Z"],
+            camera_dict["LookDirection"][0],
+            camera_dict["LookDirection"][1],
+            camera_dict["LookDirection"][2],
         )
-        resolution = (camera_dict["Resolution"]["X"], camera_dict["Resolution"]["Y"])
+        resolution = (camera_dict["Resolution"][0], camera_dict["Resolution"][1])
         focal_length = camera_dict.get("FocalLength", 50.0)
         vertical_fov = camera_dict.get("VerticalFov", 35.0)
         horizontal_fov = camera_dict.get("HorizontalFov", 50.0)

--- a/portal/data_struct/color.py
+++ b/portal/data_struct/color.py
@@ -1,15 +1,20 @@
 from enum import Enum
 from typing import Tuple, Union
 
-
 class ColorType(Enum):
     RGB = "rgb"
     RGBA = "rgba"
 
 
 class Color:
-    def __init__(self, r: int, g: int, b: int, a: float = 1.0) -> None:
+    def __init__(self, r: int, g: int, b: int, a: float = 1.0, color_space: str = "linear") -> None:
         """Initialize a Color object with RGB and optional alpha values."""
+        # Convert from sRGB to linear if input color space is sRGB
+        if color_space == 'srgb':
+            r, g, b = [int(round(Color._to_linear(x / 255) * 255)) for x in (r, g, b)]
+        elif color_space != 'linear':
+            raise ValueError("Invalid color space. Use 'srgb' or 'linear'.")
+
         self.r = self._validate_color_value(r, "r")
         self.g = self._validate_color_value(g, "g")
         self.b = self._validate_color_value(b, "b")
@@ -34,25 +39,37 @@ class Color:
             raise ValueError("Alpha must be between 0.0 and 1.0.")
         return value
 
-    def to_hex(self, type: Union[ColorType, str] = ColorType.RGBA) -> str:
+    def to_hex(self, type: Union[ColorType, str] = ColorType.RGBA, color_space: str = "linear") -> str:
         """Convert color to hexadecimal string (RGB or RGBA)."""
+        r, g, b, a = self.to_tuple(ColorType.RGBA, normalize=False, color_space=color_space)
+
         type = type.lower() if isinstance(type, str) else type.value
         if type == "rgb":
-            return f"#{self.r:02X}{self.g:02X}{self.b:02X}"
+            return f"#{r:02X}{g:02X}{b:02X}"
         elif type == "rgba":
-            alpha_int = int(round(self.a * 255))
-            return f"#{self.r:02X}{self.g:02X}{self.b:02X}{alpha_int:02X}"
+            alpha_int = int(round(a * 255))
+            return f"#{r:02X}{g:02X}{b:02X}{alpha_int:02X}"
         else:
             raise ValueError("Invalid color type. Use 'rgb' or 'rgba'.")
 
-    def to_tuple(self, type: Union[ColorType, str] = ColorType.RGBA, normalize: bool = False) -> Union[Tuple[int, int, int], Tuple[int, int, int, float]]:
+    def to_tuple(self, type: Union[ColorType, str] = ColorType.RGBA, normalize: bool = False, color_space: str = 'linear') -> Union[Tuple[int, int, int], Tuple[int, int, int, float]]:
         """Return the color as an (r, g, b) or (r, g, b, a) tuple, optionally normalized."""
+        r, g, b, a = (self.r, self.g, self.b, self.a)
+
+        # Convert to sRGB if output color space is sRGB
+        if color_space == 'srgb':
+            r, g, b = [int(round(self._to_srgb(x / 255) * 255)) for x in (r, g, b)]
+
+        # rgb or rgba tuple
         type = type.lower() if isinstance(type, str) else type.value
         if type == "rgb":
-            result = (self.r, self.g, self.b)
+            result = (r, g, b)
+        elif type == "rgba":
+            result = (r, g, b, a)
         else:
-            result = (self.r, self.g, self.b, self.a)
+            raise ValueError("Invalid color type. Use 'rgb' or 'rgba'.")
 
+        # Normalize the values to [0.0, 1.0]
         if normalize:
             return tuple(x / 255 for x in result) if type == "rgb" else (result[0] / 255, result[1] / 255, result[2] / 255, self.a)
 
@@ -65,27 +82,85 @@ class Color:
         return self.__str__()
 
     @staticmethod
-    def from_hex(hex_str: str) -> "Color":
+    def from_hex(hex_str: str, color_space="linear") -> "Color":
         """Create a Color from a hexadecimal string (#RRGGBB or #RRGGBBAA)."""
         if not hex_str.startswith("#") or len(hex_str) not in (7, 9):
             raise ValueError("Hex string must start with '#' and be 7 or 9 characters long.")
         hex_str = hex_str.lstrip("#")
         r, g, b = (int(hex_str[i:i + 2], 16) for i in (0, 2, 4))
         a = int(hex_str[6:8], 16) / 255.0 if len(hex_str) == 8 else 1.0
+
+        # Convert to linear RGB if input color space is sRGB
+        if color_space == 'srgb':
+            r, g, b = [int(round(Color._to_linear(x / 255) * 255)) for x in (r, g, b)]
+
         return Color(r, g, b, a)
 
     @staticmethod
-    def from_tuple(color_tuple: Union[Tuple[int, int, int], Tuple[int, int, int, float]]) -> "Color":
+    def from_tuple(color_tuple: Union[Tuple[int, int, int], Tuple[int, int, int, float]], color_space="linear") -> "Color":
         """Create a Color from an (r, g, b) or (r, g, b, a) tuple."""
         if len(color_tuple) not in (3, 4):
             raise ValueError("Tuple must have 3 or 4 elements.")
-        return Color(*color_tuple) if len(color_tuple) == 3 else Color(*color_tuple[:3], color_tuple[3])
+
+        # Convert to linear RGB if input color space is sRGB
+        if color_space == 'srgb':
+            r, g, b = [int(round(Color._to_linear(x / 255) * 255)) for x in color_tuple[:3]]
+        elif color_space == 'linear':
+            r, g, b = [Color._validate_color_value(x, f"{i}") for i, x in enumerate(color_tuple[:3])]
+        else:
+            raise ValueError("Invalid color space. Use 'srgb' or 'linear'.")
+
+        a = Color._validate_alpha_value(color_tuple[3]) if len(color_tuple) == 4 else 1.0
+        return Color(r, g, b, a)
 
     @staticmethod
-    def from_normalized_tuple(color_tuple: Union[Tuple[float, float, float], Tuple[float, float, float, float]]) -> "Color":
+    def from_normalized_tuple(color_tuple: Union[Tuple[float, float, float], Tuple[float, float, float, float]], color_space="linear") -> "Color":
         """Create a Color from a normalized (0.0-1.0) tuple."""
         if len(color_tuple) not in (3, 4):
             raise ValueError("Normalized tuple must have 3 or 4 elements.")
-        r, g, b = (int(round(x * 255)) for x in color_tuple[:3])
+        if not all(0.0 <= x <= 1.0 for x in color_tuple[:3]):
+            raise ValueError("Normalized tuple values must be between 0.0 and 1.0")
+        
+        # Convert to linear RGB if input color space is sRGB
+        if color_space == 'srgb':
+            r, g, b = [int(round(Color._to_linear(x) * 255)) for x in color_tuple[:3]]
+        elif color_space == 'linear':
+            r, g, b = [int(round(x * 255)) for x in color_tuple[:3]]
+        else:
+            raise ValueError("Invalid color space. Use 'srgb' or 'linear'.")
+
         a = color_tuple[3] if len(color_tuple) == 4 else 1.0
         return Color(r, g, b, a)
+
+    @staticmethod
+    def _to_srgb(value: float) -> float:
+        """Convert a single linear RGB value to sRGB."""
+        if value <= 0.0031308:
+            return value * 12.92
+        else:
+            return 1.055 * (value ** (1.0 / 2.4)) - 0.055
+
+    @staticmethod
+    def _to_linear(value: float) -> float:
+        """Convert a single sRGB value to linear RGB."""
+        if value <= 0.04045:
+            return value / 12.92
+        else:
+            return ((value + 0.055) / 1.055) ** 2.4
+
+
+    # def to_srgb(self) -> Tuple[int, int, int]:
+    #     """Convert the RGB values of the color to sRGB and return as an (r, g, b) tuple."""
+    #     return (
+    #         int(round(self.linear_to_srgb(self.r / 255) * 255)),
+    #         int(round(self.linear_to_srgb(self.g / 255) * 255)),
+    #         int(round(self.linear_to_srgb(self.b / 255) * 255)),
+    #     )
+
+    # def to_linear_rgb(self) -> Tuple[float, float, float]:
+    #     """Convert the sRGB values of the color to linear RGB and return as a normalized (r, g, b) tuple."""
+    #     return (
+    #         self.srgb_to_linear(self.r / 255),
+    #         self.srgb_to_linear(self.g / 255),
+    #         self.srgb_to_linear(self.b / 255),
+    #     )

--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -168,7 +168,7 @@ class Light:
         pos: dict = data.get("Position")
         if not all([type, pos]) or energy is None:
             raise ValueError(f"Missing required light data. Got: {data}")
-        location = (pos["X"], pos["Y"], pos["Z"])
+        location = (pos[0], pos[1], pos[2])
         light._set_light_data(name, color, energy, type, location)
 
         if type.upper() == "SPOT":
@@ -181,7 +181,7 @@ class Light:
             if not all([spot_size, spot_blend, direction]):
                 raise ValueError("Missing required spot light data")
             direction_vector = mathutils.Vector(
-                (direction["X"], direction["Y"], direction["Z"])
+                (direction[0], direction[1], direction[2])
             ).normalized()
             # TODO: implement spot light scale. Currently scale is default (1, 1, 1).
             light._set_spot_data(spot_size, spot_blend, direction_vector)
@@ -195,12 +195,12 @@ class Light:
             direction: dict = data.get("Direction")
             if not all([length_dict, width_dict, direction]):
                 raise ValueError("Missing required area light data")
-            length_vec = mathutils.Vector((length_dict["X"], length_dict["Y"], length_dict["Z"]))
+            length_vec = mathutils.Vector((length_dict[0], length_dict[1], length_dict[2]))
             length = length_vec.length
-            width_vec = mathutils.Vector((width_dict["X"], width_dict["Y"], width_dict["Z"]))
+            width_vec = mathutils.Vector((width_dict[0], width_dict[1], width_dict[2]))
             width = width_vec.length
 
-            direction_vec = mathutils.Vector((direction["X"], direction["Y"], direction["Z"]))
+            direction_vec = mathutils.Vector((direction[0], direction[1], direction[2]))
             distance = direction_vec.length
 
             # Normalize vectors
@@ -220,7 +220,7 @@ class Light:
             rotation_euler = rotation_matrix.to_euler()
 
             # center point
-            center = mathutils.Vector((pos["X"], pos["Y"], pos["Z"]))
+            center = mathutils.Vector((pos[0], pos[1], pos[2]))
 
             light._set_area_data((length, width), distance, rotation_euler)
             light.location = center

--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -25,7 +25,6 @@ class Light:
 
         # Area light properties
         self.size: Optional[tuple] = None
-        self.distance: Optional[float] = None
 
     def create_or_replace(self, object_name: str, layer_path: Optional[str] = None) -> None:
         self.object_name = object_name
@@ -62,9 +61,8 @@ class Light:
         else:
             self.rotation_euler = mathutils.Euler((0, 0, 0))
 
-    def _set_area_data(self, size: tuple, distance: float, rotation_euler: Vector) -> None:
+    def _set_area_data(self, size: tuple, rotation_euler: Vector) -> None:
         self.size = size
-        self.distance = distance
         self.rotation_euler = rotation_euler
 
     def _replace_light(self, existing_obj: Any) -> None:
@@ -87,8 +85,6 @@ class Light:
             light_data.shape = "RECTANGLE"
             light_data.size = self.size[0]
             light_data.size_y = self.size[1]
-            light_data.use_custom_distance = True
-            light_data.cutoff_distance = self.distance
             existing_obj.rotation_euler = self.rotation_euler
         else:
             raise ValueError(f"Unsupported light type: {self.type}")
@@ -109,9 +105,6 @@ class Light:
             light_data.shape = "RECTANGLE"
             light_data.size = self.size[0]
             light_data.size_y = self.size[1]
-
-            light_data.use_custom_distance = True
-            light_data.cutoff_distance = self.distance
         else:
             raise ValueError(f"Unsupported light type: {self.type}")
 
@@ -201,7 +194,6 @@ class Light:
             width = width_vec.length
 
             direction_vec = mathutils.Vector((direction[0], direction[1], direction[2]))
-            distance = direction_vec.length
 
             # Normalize vectors
             length_vec.normalize()
@@ -222,7 +214,7 @@ class Light:
             # center point
             center = mathutils.Vector((pos[0], pos[1], pos[2]))
 
-            light._set_area_data((length, width), distance, rotation_euler)
+            light._set_area_data((length, width), rotation_euler)
             light.location = center
         else:
             raise ValueError(f"Unsupported light type: {type}")

--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -155,7 +155,7 @@ class Light:
     def from_dict(data: dict) -> "Light":
         light = Light()
         name: str = data.get("Name")
-        color: tuple = Color.from_hex(data.get("Color", "#FFFFFF")).to_tuple("rgb", normalize=True)
+        color: tuple = Color.from_hex(data.get("Color", "#FFFFFF"), "srgb").to_tuple("rgb", normalize=True)
         type: str = data.get("LightType")
         intensity: float = data.get("Intensity")
         pos: dict = data.get("Position")

--- a/portal/data_struct/light.py
+++ b/portal/data_struct/light.py
@@ -35,11 +35,11 @@ class Light:
             self._create_new(layer_path)
 
     def _set_light_data(
-        self, name: str, color: tuple, energy: float, type: str, location: tuple
+        self, name: str, color: tuple, intensity: float, type: str, location: tuple
     ) -> None:
         self.name = name
         self.rgb_color = color
-        self.energy = energy
+        self.energy = intensity * 1000 # Convert to watts
         self.location = location
         if type.upper() not in ["SPOT", "POINT", "DIRECTIONAL", "RECTANGULAR"]:
             raise ValueError(f"Unsupported light type: {type}")
@@ -157,12 +157,12 @@ class Light:
         name: str = data.get("Name")
         color: tuple = Color.from_hex(data.get("Color", "#FFFFFF")).to_tuple("rgb", normalize=True)
         type: str = data.get("LightType")
-        energy: float = data.get("Intensity")
+        intensity: float = data.get("Intensity")
         pos: dict = data.get("Position")
-        if not all([type, pos]) or energy is None:
+        if not all([type, pos]) or intensity is None:
             raise ValueError(f"Missing required light data. Got: {data}")
         location = (pos[0], pos[1], pos[2])
-        light._set_light_data(name, color, energy, type, location)
+        light._set_light_data(name, color, intensity, type, location)
 
         if type.upper() == "SPOT":
             spot_size: float = data.get("SpotAngleRadians")

--- a/portal/data_struct/mesh.py
+++ b/portal/data_struct/mesh.py
@@ -1,11 +1,10 @@
 import bpy
+import numpy as np
+from mathutils import Vector
 
 from .color import Color
 from .material import Material
 from .p_types import PGeoType
-
-import numpy as np
-from mathutils import Vector
 
 
 class Mesh:
@@ -28,8 +27,8 @@ class Mesh:
         Returns:
             dict: Serialized mesh data.
         """
-        vertices = [{"X": v[0], "Y": v[1], "Z": v[2]} for v in self.vertices]
-        uvs = [{"X": uv[0], "Y": uv[1]} for uv in self.uvs]
+        vertices = [[v[0], v[1], v[2]] for v in self.vertices]
+        uvs = [[uv[0], uv[1]] for uv in self.uvs]
 
         mesh_dict = {
             "Type": PGeoType.MESH.value,
@@ -37,7 +36,7 @@ class Mesh:
             "Faces": [list(face) for face in self.faces],
             "UVs": uvs,
             "VertexColors": [
-                Color.from_normalized_tuple(col).to_hex('rgb') for col in self.vertex_colors
+                Color.from_normalized_tuple(col).to_hex("rgb") for col in self.vertex_colors
             ],
         }
         return {"Items": mesh_dict, "Meta": meta if meta else {}}
@@ -181,9 +180,9 @@ class Mesh:
     @staticmethod
     def from_dict(dict):
         """Create a Mesh object from json dictionary."""
-        vertices = [(v["X"], v["Y"], v["Z"]) for v in dict["Vertices"]]
+        vertices = [(v[0], v[1], v[2]) for v in dict["Vertices"]]
         faces = [tuple(face_list) for face_list in dict["Faces"]]
-        uvs = [(uv["X"], uv["Y"]) for uv in dict.get("UVs", [])]
+        uvs = [(uv[0], uv[1]) for uv in dict.get("UVs", [])]
         color_hexs = dict.get("VertexColors")
 
         vertex_colors = None
@@ -208,7 +207,7 @@ class Mesh:
 
         # Use bulk access to retrieve vertex data and apply transformation
         vertex_data = np.empty(len(obj.data.vertices) * 3)
-        obj.data.vertices.foreach_get('co', vertex_data)
+        obj.data.vertices.foreach_get("co", vertex_data)
         vertex_data = vertex_data.reshape(-1, 3)
 
         # Transform vertices by matrix_world
@@ -220,13 +219,13 @@ class Mesh:
         # Handle vertex colors
         if obj.data.vertex_colors:
             color_data = np.empty(len(obj.data.vertex_colors.active.data) * 4)
-            obj.data.vertex_colors.active.data.foreach_get('color', color_data)
+            obj.data.vertex_colors.active.data.foreach_get("color", color_data)
             mesh.vertex_colors = list(color_data.reshape(-1, 4))
 
         # Handle UVs
         if obj.data.uv_layers:
             uv_data = np.empty(len(obj.data.uv_layers.active.data) * 2)
-            obj.data.uv_layers.active.data.foreach_get('uv', uv_data)
+            obj.data.uv_layers.active.data.foreach_get("uv", uv_data)
             mesh.uvs = list(uv_data.reshape(-1, 2))
 
         return mesh

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,6 @@ You can create custom handlers to manipulate the data that is received. To do th
 ## Roadmap
 ### v0.3.0
 - [ ] Add mouse up / down event for the sender.
-- [ ] Simplify the mesh vertex data into a list of tuples. `[[x, y, z], [x, y, z], ...]`
 - [ ] Implement more material properties.
 
 


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [x] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [x] Does this PR require a change to the data model?
- [ ] Does this PR require a change with Portal.Gh?

### Change Log
- **feat**
  - Implement coordinates as list for more compact data model (41d5dc0), (7e00768)
  - Convert Rhino's light intensity to Blender's energy in watts using `intensity * 1000` (53ab2e3)
- **fix**
  - Correct sRGB to Linear conversion to address color mismatch between Rhino3D and Blender (36ecd9e)
  - Normalize light color (9992011)
- **chore**
  - Remove area light cutoff distance as it's unnecessary (ec3a4f6)
  - Use position as rectangular light center (9df38e3)

### Note
This PR implements necessary adaptations for the new data model where coordinates are now treated as a list for more compact data representation. It also introduces a conversion for light intensity from Rhino3D to Blender's energy in watts, ensuring consistency in lighting. Additionally, it fixes color mismatches by implementing proper sRGB to Linear color space conversion, as Rhino3D uses sRGB while Blender operates in Linear space. Lastly, unnecessary features like area light cutoff distance have been removed.
