### PR TITLE
fix: resolve layer naming conflicts & `Material` key error

### DIFF
--- a/portal/data_struct/mesh.py
+++ b/portal/data_struct/mesh.py
@@ -150,23 +150,22 @@ class Mesh:
             parent_collection = None
 
             for i, layer in enumerate(layer_names):
-                # If it's the last layer in the path, check for duplicates and rename if necessary
-                if i == len(layer_names) - 1:
-                    collection_name = layer
-                    suffix = 1
-                    while bpy.data.collections.get(collection_name):
-                        collection_name = f"{layer}_{suffix}"
-                        suffix += 1
-                else:
-                    collection_name = layer
+                # Initialize the collection as None
+                collection = None
 
-                # Create or get the collection
-                collection = bpy.data.collections.get(collection_name)
-                if not collection:
-                    collection = bpy.data.collections.new(collection_name)
-                    if parent_collection:
+                if parent_collection:
+                    # Check if the collection exists in the parent collection's children
+                    collection = parent_collection.children.get(layer)
+                    if not collection:
+                        # Create the collection under the parent collection
+                        collection = bpy.data.collections.new(layer)
                         parent_collection.children.link(collection)
-                    else:
+                else:
+                    # For root-level collections, check in the scene's collection
+                    collection = bpy.context.scene.collection.children.get(layer)
+                    if not collection:
+                        # Create the collection under the scene's collection
+                        collection = bpy.data.collections.new(layer)
                         bpy.context.scene.collection.children.link(collection)
 
                 # Set parent for the next nested layer
@@ -176,6 +175,7 @@ class Mesh:
             parent_collection.objects.link(obj)
         else:
             bpy.context.collection.objects.link(obj)
+
 
     @staticmethod
     def from_dict(dict):

--- a/portal/handlers/string_handler.py
+++ b/portal/handlers/string_handler.py
@@ -62,7 +62,7 @@ class StringHandler:
                 layer_path, layer_mat = channel_name, None
             mesh.create_or_replace(object_name=f"obj_{i}_{channel_name}", layer_path=layer_path)
 
-            if metadata and metadata["Material"]:
+            if metadata and metadata.get("Material", None):
                 # if material is string
                 if isinstance(metadata["Material"], str):
                     mesh.apply_material(metadata["Material"])


### PR DESCRIPTION
### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?

### Description of Change
- Items in same layer created together (94bfc1020de53e6c6119a49b1240b0f938a24fff)
- Items in separate branches get suffix to avoid conflict
- fix: key error if material property does not exist in mesh JSON (ef17fa522dfcc9a50b19f3f74b00e669110616e5)