### PR TITLE
Fix server auto-start on file open and ensure graceful server shutdown before closing Blender

### DIFF
--- a/portal/ui/operators/modal.py
+++ b/portal/ui/operators/modal.py
@@ -23,6 +23,8 @@ class ModalOperator(bpy.types.Operator):
         self.frame_change_handler = None
         self.scene_update_handler = None
         self.custom_event_handler = None
+        self.connection_pre_save_handler = None
+        self.connection_post_save_handler = None
         self.last_update_time = 0  # Track the last update time for the delay
 
     def modal(self, context, event):
@@ -187,8 +189,19 @@ class ModalOperator(bpy.types.Operator):
             self.cancel(bpy.context)
             return True
         return False
+    
+    def _set_connection_state(self, scene, connection, state):
+        connection.running = state
 
     def _register_event_handlers(self, connection):
+        # set connection.running to False before saving to prevent next time starting automatically
+        self.connection_pre_save_handler = lambda scene: self._set_connection_state(scene, connection, False)
+        bpy.app.handlers.save_pre.append(self.connection_pre_save_handler)
+
+        # set connection.running to True after saving back to the original state
+        self.connection_post_save_handler = lambda scene: self._set_connection_state(scene, connection, True)
+        bpy.app.handlers.save_post.append(self.connection_post_save_handler)
+
         if "RENDER_COMPLETE" in connection.event_types:
             self.render_complete_handler = lambda scene: self._send_data_on_event(scene, connection)
             bpy.app.handlers.render_complete.append(self.render_complete_handler)
@@ -215,6 +228,14 @@ class ModalOperator(bpy.types.Operator):
                 return {"CANCELLED"}
 
     def _unregister_event_handlers(self):
+        if self.connection_pre_save_handler:
+            bpy.app.handlers.save_pre.remove(self.connection_pre_save_handler)
+            self.connection_pre_save_handler = None
+        
+        if self.connection_post_save_handler:
+            bpy.app.handlers.save_post.remove(self.connection_post_save_handler)
+            self.connection_post_save_handler = None
+
         if self.render_complete_handler:
             bpy.app.handlers.render_complete.remove(self.render_complete_handler)
             self.render_complete_handler = None

--- a/portal/ui/operators/modal.py
+++ b/portal/ui/operators/modal.py
@@ -1,5 +1,5 @@
-import time
 import queue
+import time
 import traceback
 
 import bpy
@@ -79,6 +79,15 @@ class ModalOperator(bpy.types.Operator):
 
         MODAL_OPERATORS.pop(self.uuid, None)
         self._unregister_event_handlers()
+
+        # Stop the server manager if running
+        connection = self._get_connection(context)
+        if connection:
+            server_manager = self._get_server_manager(connection)
+            if server_manager and server_manager.is_running():
+                server_manager.stop_server()
+            connection.running = False
+            CONNECTION_MANAGER.remove(self.uuid)
 
         return None
 


### PR DESCRIPTION
### Change Type
- [ ] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Checklist
- [ ] Does this PR introduce a breaking change?
- [ ] Does this PR require a documentation update?
- [ ] Does this PR require a change to the data model?
- [ ] Does this PR require a change with Portal.Gh?

### Change Log
- **fix**
  - Prevent server from auto-starting when opening a saved .blend file by resetting connection state before save and restoring it after save (cc413d7)
  - Ensure server shuts down gracefully before closing Blender to avoid issues (77735ee)
